### PR TITLE
(upstream update) Add high-frequency spindle output option. Minor parking motion re-factoring

### DIFF
--- a/doc/log/commit_log_v1.1.txt
+++ b/doc/log/commit_log_v1.1.txt
@@ -1,6 +1,19 @@
 ----------------
 Date: 2016-10-25
 Author: chamnit
+Subject: Mandate all probe cycles ignore feed overrides.
+
+- For repeatability reasons, all G38.x probe cycles ignore feed rate
+overrides and move at their programmed speed.
+
+- The mandate can be removed with a new config.h option.
+
+- Updated the documentation to reflect the change.
+
+
+----------------
+Date: 2016-10-25
+Author: chamnit
 Subject: Resolved parking accessory handling issue.
 
 - Yikes. Totally borked the last parking “fix”. Testing shows that all

--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -139,9 +139,10 @@
 
   // Prescaled, 8-bit Fast PWM mode.
   #define SPINDLE_TCCRA_INIT_MASK   ((1<<WGM20) | (1<<WGM21))  // Configures fast PWM mode.
-  // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS21)                  // 1/8 prescaler -> 7.8kHz (Used in v0.9)
+  // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS20)               // Disable prescaler -> 62.5kHz
+  // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS21)               // 1/8 prescaler -> 7.8kHz (Used in v0.9)
   // #define SPINDLE_TCCRB_INIT_MASK   ((1<<CS21) | (1<<CS20)) // 1/32 prescaler -> 1.96kHz
-  #define SPINDLE_TCCRB_INIT_MASK   (1<<CS22)               // 1/64 prescaler -> 0.98kHz
+  #define SPINDLE_TCCRB_INIT_MASK      (1<<CS22)               // 1/64 prescaler -> 0.98kHz (J-tech laser)
 
   // NOTE: On the 328p, these must be the same as the SPINDLE_ENABLE settings.
   #define SPINDLE_PWM_DDR	  DDRB

--- a/grbl/grbl.h
+++ b/grbl/grbl.h
@@ -23,7 +23,7 @@
 
 // Grbl versioning system
 #define GRBL_VERSION "1.1d"
-#define GRBL_VERSION_BUILD "20161025"
+#define GRBL_VERSION_BUILD "20161026"
 
 // Define standard libraries used by Grbl.
 #include <avr/io.h>

--- a/grbl/protocol.c
+++ b/grbl/protocol.c
@@ -579,14 +579,14 @@ static void protocol_exec_rt_suspend()
               if (parking_target[PARKING_AXIS] < retract_waypoint) {
                 parking_target[PARKING_AXIS] = retract_waypoint;
                 pl_data->feed_rate = PARKING_PULLOUT_RATE;
-                // NOTE: Retain accessory state for retract motion, then clear for remaining parking motions.
-                pl_data->condition |= (restore_condition & PL_COND_ACCESSORY_MASK);
+                pl_data->condition |= (restore_condition & PL_COND_ACCESSORY_MASK); // Retain accessory state
                 pl_data->spindle_speed = restore_spindle_speed;
                 mc_parking_motion(parking_target, pl_data);
-                pl_data->condition = (PL_COND_FLAG_SYSTEM_MOTION|PL_COND_FLAG_NO_FEED_OVERRIDE);
-                pl_data->spindle_speed = 0.0;
               }
 
+              // NOTE: Clear accessory state after retract and after an aborted restore motion.
+              pl_data->condition = (PL_COND_FLAG_SYSTEM_MOTION|PL_COND_FLAG_NO_FEED_OVERRIDE);
+              pl_data->spindle_speed = 0.0;
               spindle_set_state(SPINDLE_DISABLE,0.0); // De-energize
               coolant_set_state(COOLANT_DISABLE); // De-energize
 
@@ -677,10 +677,8 @@ static void protocol_exec_rt_suspend()
                   // Regardless if the retract parking motion was a valid/safe motion or not, the
                   // restore parking motion should logically be valid, either by returning to the
                   // original position through valid machine space or by not moving at all.
-									// NOTE: If retract is restarted, spindle and coolant states will be cleared in
-									// the beginning of the retract routine.
                   pl_data->feed_rate = PARKING_PULLOUT_RATE;
-									pl_data->condition |= (restore_condition & PL_COND_ACCESSORY_MASK);
+									pl_data->condition |= (restore_condition & PL_COND_ACCESSORY_MASK); // Restore accessory state
 									pl_data->spindle_speed = restore_spindle_speed;
                   mc_parking_motion(restore_target, pl_data);
                 }


### PR DESCRIPTION
- Some laser controllers were reported to need a very high PWM
frequency. Added a line to enable this in cpu_map.h, if needed.

- Cleaned up some of the parking code. Mostly just editing the comments.

- Moved the accessory state resetting after the initial parking
retract. Should ensure the accessory state is properly handled upon an
aborted parking restore. Not certain if this was a problem before
though. Just to be sure.